### PR TITLE
Feature/http endpoints check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,4 +13,4 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run golangci-lint
-      uses: actions-contrib/golangci-lint@v1
+      uses: golangci/golangci-lint-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 cmd/http-check/http-check
 cmd/http-perf/http-perf
 cmd/http-json/http-json
+cmd/http-endpoints-check/http-endpoints-check
 
 # Test binary, build with `go test -c`
 *.test

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -91,6 +91,36 @@ builds:
       - windows_386
       - windows_amd64
 
+  - main: ./cmd/http-endpoints-check/main.go
+    id: "http-endpoints-check"
+    env:
+    - CGO_ENABLED=0
+    ldflags: '-s -w -X github.com/sensu-community/sensu-plugin-sdk/version.version={{.Version}} -X github.com/sensu-community/sensu-plugin-sdk/version.commit={{.Commit}} -X github.com/sensu-community/sensu-plugin-sdk/version.date={{.Date}}'
+    binary: bin/http-endpoints-check
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - 386
+      - arm
+      - arm64
+    goarm:
+      - 5
+      - 6
+      - 7
+    targets:
+      - darwin_amd64
+      - linux_386
+      - linux_amd64
+      - linux_arm_5
+      - linux_arm_6
+      - linux_arm_7
+      - linux_arm64
+      - windows_386
+      - windows_amd64
+
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_sha512-checksums.txt"
   algorithm: sha512

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+- Added http-endpoints-check binary. This command is able to generate separate events for multiple urls.
+
 ## [0.4.0] - 2021-01-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Sensu Bonsai Asset](https://img.shields.io/badge/Bonsai-Download%20Me-brightgreen.svg?colorB=89C967&logo=sensu)](https://bonsai.sensu.io/assets/nixwiz/http-checks)
-![Go Test](https://github.com/nixwiz/http-checks/workflows/Go%20Test/badge.svg)
-![goreleaser](https://github.com/nixwiz/http-checks/workflows/goreleaser/badge.svg)
+[![Sensu Bonsai Asset](https://img.shields.io/badge/Bonsai-Download%20Me-brightgreen.svg?colorB=89C967&logo=sensu)](https://bonsai.sensu.io/assets/sensu/http-checks)
+![Go Test](https://github.com/sensu/http-checks/workflows/Go%20Test/badge.svg)
+![goreleaser](https://github.com/sensu/http-checks/workflows/goreleaser/badge.svg)
 
 # http-checks
 
@@ -239,7 +239,7 @@ using an asset, please consider doing so! If you're using sensuctl 5.13 with
 Sensu Backend 5.13 or later, you can use the following command to add the asset:
 
 ```
-sensuctl asset add nixwiz/http-checks
+sensuctl asset add sensu/http-checks
 ```
 
 If you're using an earlier version of sensuctl, you can find the asset on the [Bonsai Asset Index][3].
@@ -260,7 +260,7 @@ spec:
   subscriptions:
   - system
   runtime_assets:
-  - nixwiz/http-checks
+  - sensu/http-checks
 ```
 
 #### http-perf
@@ -277,7 +277,7 @@ spec:
   subscriptions:
   - system
   runtime_assets:
-  - nixwiz/http-checks
+  - sensu/http-checks
   output_metric_format: nagios_perfdata
   output_metric-handlers:
   - influxdb
@@ -297,7 +297,7 @@ spec:
   subscriptions:
   - system
   runtime_assets:
-  - nixwiz/http-checks
+  - sensu/http-checks
 ```
 
 ## Installation from source
@@ -321,7 +321,7 @@ For more information about contributing to this plugin, see [Contributing][4].
 
 [1]: https://docs.sensu.io/sensu-go/latest/reference/checks/
 [2]: https://docs.sensu.io/sensu-go/latest/reference/assets/
-[3]: https://bonsai.sensu.io/assets/nixwiz/http-checks
+[3]: https://bonsai.sensu.io/assets/sensu/http-checks
 [4]: https://github.com/sensu/sensu-go/blob/master/CONTRIBUTING.md
 [5]: https://github.com/ncr-devops-platform/nagiosfoundation
 [6]: https://github.com/stedolan/jq

--- a/README.md
+++ b/README.md
@@ -239,8 +239,8 @@ http-json OK:  The value 200 found at .status matched with expression "< 300" an
 HTTP Status/String Check for multiple endpoints
 
 Usage:
-  http-check [flags]
-  http-check [command]
+  http-endpoints-check [flags]
+  http-endpoints-check [command]
 
 Available Commands:
   help        Help about any command
@@ -249,7 +249,8 @@ Available Commands:
 Flags:
       --create-event               Create event for url, can be overridden by endpoint json attribute of same name
   -n, --dry-run                    Do not actually create events. Output http requests that would have created events instead.
-  -e, --endpoints string           An array of http endpoints to check.
+  -e, --endpoints string           A JSON array of http endpoints to check. Conficts with --endpoints-file.
+  -f, --endpoints-file string      File holding a JSON array of http endpoints to check. Conflicts with --endpoints.
       --event-check-name string    Check name to use in generated event, can be overridden by endpoint json attribute of same name
       --event-entity-name string   Entity name to use in generated event, can be overridden by endpoint json attribute of same name
       --event-handlers strings     Comma separated list of handlers to use in generated event, can be overridden by endpoint json attribute of same name
@@ -265,7 +266,6 @@ Flags:
   -t, --trusted-ca-file string     TLS CA certificate bundle in PEM format, can be overridden by endpoint json attribute of same name
   -u, --url string                 URL to test, can be overridden by endpoint json attribute of same name (default "http://localhost:80/")
   -h, --help                       help for http-check
-
 ```
 
 #### Example(s)

--- a/cmd/http-endpoints-check/main.go
+++ b/cmd/http-endpoints-check/main.go
@@ -462,8 +462,8 @@ func executeCheck(event *types.Event) (int, error) {
 			overallError = multierror.Append(overallError, endpoint.Error)
 		}
 		if (!plugin.SuppressOKOutput && endpoint.Status == 0) || endpoint.Status > 0 {
-			fmt.Printf("Entity: %s URL: %s Status: %v Output: %v\n",
-				endpoint.EntityName, endpoint.URL, endpoint.Status, endpoint.StatusMsg)
+			fmt.Printf("URL: %s Status: %v Output: %v\n",
+				endpoint.URL, endpoint.Status, endpoint.StatusMsg)
 		}
 	}
 	return overallStatus, overallError
@@ -524,7 +524,11 @@ func (e *Endpoint) generateEvent() error {
 	//fmt.Println(string(eventJSON))
 	if plugin.DryRun {
 		fmt.Printf("URL: %s\n", e.URL)
-		fmt.Printf("  Post to API: %s\n  Event Data: %s\n", e.EventsAPI, string(eventJSON))
+		fmt.Printf("  Entity Name: %s\n", event.Entity.Name)
+		fmt.Printf("  Check Name: %s\n", event.Check.Name)
+		fmt.Printf("  Check Status: %v\n", event.Check.Status)
+		fmt.Printf("  Check Output: %s\n", event.Check.Output)
+		fmt.Printf("  Event API: %s\n  Event Data: %s\n", e.EventsAPI, string(eventJSON))
 	} else {
 		_, err = http.Post(e.EventsAPI, "application/json", bytes.NewBuffer(eventJSON))
 		if err != nil {

--- a/cmd/http-endpoints-check/main.go
+++ b/cmd/http-endpoints-check/main.go
@@ -72,9 +72,9 @@ var (
 	tlsConfig tls.Config
 	plugin    = Config{
 		PluginConfig: sensu.PluginConfig{
-			Name:     "http-check",
+			Name:     "http-endpoints-check",
 			Short:    "HTTP Status/String Check for multiple endpoints",
-			Keyspace: "sensu.io/plugins/http-check/config",
+			Keyspace: "sensu.io/plugins/http-endpoints-check/config",
 		},
 	}
 
@@ -85,7 +85,7 @@ var (
 			Argument:  "endpoints",
 			Shorthand: "e",
 			Default:   "",
-			Usage:     `An array of http endpoints to check.`,
+			Usage:     `A JSON array of http endpoints to check. Conficts with --endpoints-file.`,
 			Value:     &plugin.Endpoints,
 		},
 		{
@@ -94,7 +94,7 @@ var (
 			Argument:  "endpoints-file",
 			Shorthand: "f",
 			Default:   "",
-			Usage:     `JSON file corresponding to array of http endpoints to check.`,
+			Usage:     `File holding a JSON array of http endpoints to check. Conflicts with --endpoints.`,
 			Value:     &plugin.EndpointsFile,
 		},
 		{

--- a/cmd/http-endpoints-check/main.go
+++ b/cmd/http-endpoints-check/main.go
@@ -71,7 +71,7 @@ var (
 	plugin    = Config{
 		PluginConfig: sensu.PluginConfig{
 			Name:     "http-check",
-			Short:    "HTTP Status/String Check",
+			Short:    "HTTP Status/String Check for multiple endpoints",
 			Keyspace: "sensu.io/plugins/http-check/config",
 		},
 	}

--- a/cmd/http-endpoints-check/main.go
+++ b/cmd/http-endpoints-check/main.go
@@ -478,7 +478,7 @@ func executeCheck(event *types.Event) (int, error) {
 	if plugin.DryRun {
 		fmt.Printf("Dry-run:: Waiting for all checks to complete\n")
 	}
-	for e, _ := range endpoints {
+	for e := range endpoints {
 		wg.Add(1)
 		go checkEndpoint(&endpoints[e], &wg)
 	}
@@ -494,7 +494,7 @@ func executeCheck(event *types.Event) (int, error) {
 	if plugin.DryRun {
 		fmt.Printf("Dry-run:: Waiting for all events to be created\n")
 	}
-	for e, _ := range endpoints {
+	for e := range endpoints {
 		wg.Add(1)
 		go createEvent(&endpoints[e], &wg)
 	}

--- a/cmd/http-endpoints-check/main.go
+++ b/cmd/http-endpoints-check/main.go
@@ -35,7 +35,7 @@ type Endpoint struct {
 	InsecureSkipVerify bool     `json:"insecure-skip-verify"`
 	CreateEvent        bool     `json:"create-event"`
 	EntityName         string   `json:"event-entity-name"`
-	CheckName          string   `json:"event-entity-name"`
+	CheckName          string   `json:"event-check-name"`
 	Handlers           []string `json:"event-handlers"`
 	EventsAPI          string   `json:"events-api"`
 	Error              error
@@ -400,7 +400,6 @@ func executeCheck(event *types.Event) (int, error) {
 			endpoints[e].StatusMsg = fmt.Sprintf(
 				"%s CRITICAL: HTTP Status %v for %s\n",
 				plugin.PluginConfig.Name, resp.StatusCode, endpoint.URL)
-			break
 		// resp.StatusCode will ultimately be 200 for successful redirects
 		// so instead we check to see if the current URL matches the requested
 		// URL
@@ -410,7 +409,6 @@ func executeCheck(event *types.Event) (int, error) {
 			endpoints[e].StatusMsg = fmt.Sprintf(
 				"%s OK: HTTP Status %v for %s (redirect from %s)\n",
 				plugin.PluginConfig.Name, resp.StatusCode, resp.Request.URL, endpoint.URL)
-			break
 		// But, if we've disabled redirects, this should work
 		case resp.StatusCode >= http.StatusMultipleChoices:
 			var extra string
@@ -423,21 +421,18 @@ func executeCheck(event *types.Event) (int, error) {
 			endpoints[e].StatusMsg = fmt.Sprintf(
 				"%s WARNING: HTTP Status %v for %s %s\n",
 				plugin.PluginConfig.Name, resp.StatusCode, endpoint.URL, extra)
-			break
 		case resp.StatusCode == -1:
 			endpoints[e].Error = nil
 			endpoints[e].Status = sensu.CheckStateUnknown
 			endpoints[e].StatusMsg = fmt.Sprintf(
 				"%s UNKNOWN: HTTP Status %v for %s\n",
 				plugin.PluginConfig.Name, resp.StatusCode, endpoint.URL)
-			break
 		default:
 			endpoints[e].Error = nil
 			endpoints[e].Status = sensu.CheckStateOK
 			endpoints[e].StatusMsg = fmt.Sprintf(
 				"%s OK: HTTP Status %v for %s\n",
 				plugin.PluginConfig.Name, resp.StatusCode, endpoint.URL)
-			break
 		}
 	}
 	overallStatus := 0

--- a/cmd/http-endpoints-check/main.go
+++ b/cmd/http-endpoints-check/main.go
@@ -1,0 +1,517 @@
+/* Portions of this code are based on and/or derived from the HTTP
+   check found in the NCR DevOps Platform nagiosfoundation collection of
+   checks found at https://github.com/ncr-devops-platform/nagiosfoundation */
+
+package main
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/sensu-community/sensu-plugin-sdk/sensu"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/sensu/sensu-go/types"
+)
+
+// Endpoint represents a http check request
+type Endpoint struct {
+	URL                string   `json:"url"`
+	Headers            []string `json:"header"`
+	SearchString       string   `json:"search-string"`
+	RedirectOK         bool     `json:"redirect-ok"`
+	Timeout            int      `json:"timeout"`
+	MTLSKeyFile        string   `json:"mtls-key-file"`
+	MTLSCertFile       string   `json:"mtls-cert-file"`
+	TrustedCAFile      string   `json:"trusted-ca"`
+	InsecureSkipVerify bool     `json:"insecure-skip-verify"`
+	CreateEvent        bool     `json:"create-event"`
+	EntityName         string   `json:"event-entity-name"`
+	CheckName          string   `json:"event-entity-name"`
+	Handlers           []string `json:"event-handlers"`
+	EventsAPI          string   `json:"events-api"`
+	Error              error
+	Status             int
+	StatusMsg          string
+}
+
+// Config represents the check plugin config.
+type Config struct {
+	sensu.PluginConfig
+	Endpoints          string
+	SuppressOKOutput   bool
+	URL                string
+	SearchString       string
+	TrustedCAFile      string
+	InsecureSkipVerify bool
+	RedirectOK         bool
+	Timeout            int
+	Headers            []string
+	MTLSKeyFile        string
+	MTLSCertFile       string
+	CreateEvent        bool
+	EntityName         string
+	CheckName          string
+	Handlers           []string
+	EventsAPI          string
+}
+
+var (
+	endpoints []Endpoint
+	tlsConfig tls.Config
+	plugin    = Config{
+		PluginConfig: sensu.PluginConfig{
+			Name:     "http-check",
+			Short:    "HTTP Status/String Check",
+			Keyspace: "sensu.io/plugins/http-check/config",
+		},
+	}
+
+	options = []*sensu.PluginConfigOption{
+		{
+			Path:      "endpoints",
+			Env:       "",
+			Argument:  "endpoints",
+			Shorthand: "e",
+			Default:   "",
+			Usage:     `An array of http endpoints to check.`,
+			Value:     &plugin.Endpoints,
+		},
+		{
+			Path:      "suppress-ok-output",
+			Env:       "",
+			Argument:  "suppress-ok-output",
+			Shorthand: "S",
+			Default:   false,
+			Usage:     "Aside from overal status, only output failures",
+			Value:     &plugin.SuppressOKOutput,
+		},
+
+		{
+			Path:      "url",
+			Env:       "CHECK_URL",
+			Argument:  "url",
+			Shorthand: "u",
+			Default:   "http://localhost:80/",
+			Usage:     "URL to test, can be overridden by endpoint json attribute of same name",
+			Value:     &plugin.URL,
+		},
+		{
+			Path:      "search-string",
+			Env:       "CHECK_SEARCH_STRING",
+			Argument:  "search-string",
+			Shorthand: "s",
+			Default:   "",
+			Usage:     "String to search for, if not provided do status check only, can be overridden by endpoint json attribute of same name",
+			Value:     &plugin.SearchString,
+		},
+		{
+			Path:      "insecure-skip-verify",
+			Env:       "",
+			Argument:  "insecure-skip-verify",
+			Shorthand: "i",
+			Default:   false,
+			Usage:     "Skip TLS certificate verification (not recommended!), can be overridden by endpoint json attribute of same name",
+			Value:     &plugin.InsecureSkipVerify,
+		},
+		{
+			Path:      "trusted-ca-file",
+			Env:       "",
+			Argument:  "trusted-ca-file",
+			Shorthand: "t",
+			Default:   "",
+			Usage:     "TLS CA certificate bundle in PEM format, can be overridden by endpoint json attribute of same name",
+			Value:     &plugin.TrustedCAFile,
+		},
+		{
+			Path:      "redirect-ok",
+			Env:       "",
+			Argument:  "redirect-ok",
+			Shorthand: "r",
+			Default:   false,
+			Usage:     "Allow redirects, can be overridden by endpoint json attribute of same name",
+			Value:     &plugin.RedirectOK,
+		},
+		{
+			Path:      "timeout",
+			Env:       "",
+			Argument:  "timeout",
+			Shorthand: "T",
+			Default:   15,
+			Usage:     "Request timeout in seconds, can be overridden by endpoint json attribute of same name",
+			Value:     &plugin.Timeout,
+		},
+		{
+			Path:      "header",
+			Env:       "",
+			Argument:  "header",
+			Shorthand: "H",
+			Default:   []string{},
+			Usage:     "Additional header(s) to send in check request, can be overridden by endpoint json attribute of same name",
+			Value:     &plugin.Headers,
+		},
+		{
+			Path:      "mtls-key-file",
+			Env:       "",
+			Argument:  "mtls-key-file",
+			Shorthand: "K",
+			Default:   "",
+			Usage:     "Key file for mutual TLS auth in PEM format, can be overridden by endpoint json attribute of same name",
+			Value:     &plugin.MTLSKeyFile,
+		},
+		{
+			Path:      "mtls-cert-file",
+			Env:       "",
+			Argument:  "mtls-cert-file",
+			Shorthand: "C",
+			Default:   "",
+			Usage:     "Certificate file for mutual TLS auth in PEM format, can be overridden by endpoint json attribute of same name",
+			Value:     &plugin.MTLSCertFile,
+		},
+		{
+			Path:     "create-event",
+			Env:      "",
+			Argument: "create-event",
+			Default:  false,
+			Usage:    "Create event for url, can be overridden by endpoint json attribute of same name",
+			Value:    &plugin.CreateEvent,
+		},
+		{
+			Path:     "event-check-name",
+			Env:      "",
+			Argument: "event-check-name",
+			Default:  "",
+			Usage:    "Check name to use in generated event, can be overridden by endpoint json attribute of same name",
+			Value:    &plugin.CheckName,
+		},
+		{
+			Path:     "event-entity-name",
+			Env:      "",
+			Argument: "event-entity-name",
+			Default:  "",
+			Usage:    "Entity name to use in generated event, can be overridden by endpoint json attribute of same name",
+			Value:    &plugin.EntityName,
+		},
+		{
+			Path:     "event-handlers",
+			Env:      "",
+			Argument: "event-handlers",
+			Default:  []string{},
+			Usage:    "Comma separated list of handlers to use in generated event, can be overridden by endpoint json attribute of same name",
+			Value:    &plugin.Handlers,
+		},
+		{
+			Path:     "events-api",
+			Env:      "",
+			Argument: "events-api",
+			Default:  "http://localhost:3031/events",
+			Usage:    "Events API endpoint to use when generating events, can be overridden by endpoint json attribute of same name",
+			Value:    &plugin.EventsAPI,
+		},
+	}
+)
+
+func main() {
+	check := sensu.NewGoCheck(&plugin.PluginConfig, options, checkArgs, executeCheck, false)
+	check.Execute()
+}
+
+func checkArgs(event *types.Event) (int, error) {
+	var err error
+	if len(plugin.Endpoints) == 0 {
+		endpoints, err = parseEndpoints(`[{}]`)
+		if err != nil {
+			return sensu.CheckStateUnknown, fmt.Errorf("cannot parse config")
+		}
+	} else {
+		endpoints, err = parseEndpoints(plugin.Endpoints)
+		if err != nil {
+			return sensu.CheckStateUnknown, fmt.Errorf("cannot parse --endpoints string, please check documented examples.")
+		}
+	}
+	if len(endpoints) == 0 {
+		return sensu.CheckStateUnknown, fmt.Errorf("no endpoints parsed, please check documented examples.")
+	}
+
+	for _, endpoint := range endpoints {
+
+		if len(endpoint.URL) == 0 {
+			return sensu.CheckStateWarning, fmt.Errorf("--url or CHECK_URL environment variable is required")
+		}
+		if len(endpoint.Headers) > 0 {
+			for _, header := range endpoint.Headers {
+				headerSplit := strings.SplitN(header, ":", 2)
+				if len(headerSplit) != 2 {
+					return sensu.CheckStateWarning, fmt.Errorf("--header %q value malformed should be \"Header-Name: Header Value\"", header)
+				}
+			}
+		}
+		if len(endpoint.TrustedCAFile) > 0 {
+			caCertPool, err := corev2.LoadCACerts(endpoint.TrustedCAFile)
+			if err != nil {
+				return sensu.CheckStateWarning, fmt.Errorf("Error loading specified CA file")
+			}
+			tlsConfig.RootCAs = caCertPool
+		}
+		tlsConfig.InsecureSkipVerify = endpoint.InsecureSkipVerify
+
+		tlsConfig.CipherSuites = corev2.DefaultCipherSuites
+
+		if (len(endpoint.MTLSKeyFile) > 0 && len(endpoint.MTLSCertFile) == 0) || (len(endpoint.MTLSCertFile) > 0 && len(endpoint.MTLSKeyFile) == 0) {
+			return sensu.CheckStateWarning, fmt.Errorf("mTLS auth requires both --mtls-key-file and --mtls-cert-file")
+		}
+		if len(endpoint.MTLSKeyFile) > 0 && len(endpoint.MTLSCertFile) > 0 {
+			cert, err := tls.LoadX509KeyPair(endpoint.MTLSCertFile, endpoint.MTLSKeyFile)
+			if err != nil {
+				return sensu.CheckStateWarning, fmt.Errorf("Failed to load mTLS key pair %s/%s: %v", endpoint.MTLSCertFile, endpoint.MTLSKeyFile, err)
+			}
+			tlsConfig.Certificates = []tls.Certificate{cert}
+		}
+	}
+
+	return sensu.CheckStateOK, nil
+}
+
+func executeCheck(event *types.Event) (int, error) {
+	client := http.DefaultClient
+	for e, endpoint := range endpoints {
+		fmt.Printf("Search String: %v\n", endpoint.SearchString)
+		client.Transport = http.DefaultTransport
+		client.Timeout = time.Duration(endpoint.Timeout) * time.Second
+		if !endpoint.RedirectOK {
+			client.CheckRedirect = func(req *http.Request, via []*http.Request) error { return http.ErrUseLastResponse }
+		}
+
+		checkURL, err := url.Parse(endpoint.URL)
+		if len(endpoint.EntityName) == 0 {
+			endpoints[e].EntityName = checkURL.Host
+		}
+		if len(endpoint.CheckName) == 0 {
+			// Make a Regex to say we only want letters and numbers
+			reg, err := regexp.Compile("[^a-zA-Z0-9]+")
+			if err != nil {
+				break
+			}
+			processedString := reg.ReplaceAllString(checkURL.Path, "_")
+			if len(processedString) == 0 {
+				processedString = "root_path"
+			}
+			endpoints[e].CheckName = fmt.Sprintf("http_check-%s", processedString)
+		}
+		if err != nil {
+			endpoints[e].Error = err
+			endpoints[e].Status = sensu.CheckStateCritical
+			endpoints[e].StatusMsg = fmt.Sprintf(
+				"%s CRITICAL: error parsing URL\n",
+				plugin.PluginConfig.Name)
+			break
+		}
+		if checkURL.Scheme == "https" {
+			client.Transport.(*http.Transport).TLSClientConfig = &tlsConfig
+		}
+
+		req, err := http.NewRequest("GET", endpoint.URL, nil)
+		if err != nil {
+			endpoints[e].Error = err
+			endpoints[e].Status = sensu.CheckStateCritical
+			endpoints[e].StatusMsg = fmt.Sprintf(
+				"%s CRITICAL: error creating request\n",
+				plugin.PluginConfig.Name)
+			break
+		}
+
+		if len(endpoint.Headers) > 0 {
+			for _, header := range endpoint.Headers {
+				headerSplit := strings.SplitN(header, ":", 2)
+				req.Header.Set(strings.TrimSpace(headerSplit[0]), strings.TrimSpace(headerSplit[1]))
+			}
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			endpoints[e].Error = err
+			endpoints[e].Status = sensu.CheckStateCritical
+			endpoints[e].StatusMsg = fmt.Sprintf(
+				"%s CRITICAL: error making request\n",
+				plugin.PluginConfig.Name)
+			break
+		}
+		defer resp.Body.Close()
+
+		if err != nil {
+			endpoints[e].Error = err
+			endpoints[e].Status = sensu.CheckStateCritical
+			endpoints[e].StatusMsg = "critical"
+			endpoints[e].StatusMsg = fmt.Sprintf(
+				"%s CRITICAL: error making request\n",
+				plugin.PluginConfig.Name)
+			break
+		}
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			endpoints[e].Error = err
+			endpoints[e].Status = sensu.CheckStateCritical
+			endpoints[e].StatusMsg = "critical"
+			endpoints[e].StatusMsg = fmt.Sprintf(
+				"%s CRITICAL: error reading body\n",
+				plugin.PluginConfig.Name)
+			break
+		}
+
+		if len(endpoint.SearchString) > 0 {
+			if strings.Contains(string(body), endpoint.SearchString) {
+				endpoints[e].Error = nil
+				endpoints[e].Status = sensu.CheckStateOK
+				endpoints[e].StatusMsg = fmt.Sprintf(
+					"%s OK: found \"%s\" at %s\n",
+					plugin.PluginConfig.Name, endpoint.SearchString, resp.Request.URL)
+				break
+			}
+			endpoints[e].Error = nil
+			endpoints[e].Status = sensu.CheckStateCritical
+			endpoints[e].StatusMsg = fmt.Sprintf(
+				"%s CRITICAL: \"%s\" not found at %s\n",
+				plugin.PluginConfig.Name, endpoint.SearchString, resp.Request.URL)
+			break
+		}
+
+		switch {
+		case resp.StatusCode >= http.StatusBadRequest:
+			endpoints[e].Error = nil
+			endpoints[e].Status = sensu.CheckStateCritical
+			endpoints[e].StatusMsg = fmt.Sprintf(
+				"%s CRITICAL: HTTP Status %v for %s\n",
+				plugin.PluginConfig.Name, resp.StatusCode, endpoint.URL)
+			fmt.Printf("Status: %v Msg: %v Err: %v\n", endpoint.Status, endpoint.StatusMsg, endpoint.Error)
+			break
+		// resp.StatusCode will ultimately be 200 for successful redirects
+		// so instead we check to see if the current URL matches the requested
+		// URL
+		case resp.Request.URL.String() != endpoint.URL && endpoint.RedirectOK:
+			endpoints[e].Error = nil
+			endpoints[e].Status = sensu.CheckStateOK
+			endpoints[e].StatusMsg = fmt.Sprintf(
+				"%s OK: HTTP Status %v for %s (redirect from %s)\n",
+				plugin.PluginConfig.Name, resp.StatusCode, resp.Request.URL, endpoint.URL)
+			break
+		// But, if we've disabled redirects, this should work
+		case resp.StatusCode >= http.StatusMultipleChoices:
+			var extra string
+			redirectURL := resp.Header.Get("Location")
+			if len(redirectURL) > 0 {
+				extra = fmt.Sprintf(" (redirects to %s)", redirectURL)
+			}
+			endpoints[e].Error = nil
+			endpoints[e].Status = sensu.CheckStateWarning
+			endpoints[e].StatusMsg = fmt.Sprintf(
+				"%s WARNING: HTTP Status %v for %s %s\n",
+				plugin.PluginConfig.Name, resp.StatusCode, endpoint.URL, extra)
+			break
+		case resp.StatusCode == -1:
+			endpoints[e].Error = nil
+			endpoints[e].Status = sensu.CheckStateUnknown
+			endpoints[e].StatusMsg = fmt.Sprintf(
+				"%s UNKNOWN: HTTP Status %v for %s\n",
+				plugin.PluginConfig.Name, resp.StatusCode, endpoint.URL)
+			break
+		default:
+			endpoints[e].Error = nil
+			endpoints[e].Status = sensu.CheckStateOK
+			endpoints[e].StatusMsg = fmt.Sprintf(
+				"%s OK: HTTP Status %v for %s\n",
+				plugin.PluginConfig.Name, resp.StatusCode, endpoint.URL)
+			break
+		}
+	}
+	overallStatus := 0
+	for e, endpoint := range endpoints {
+		if endpoint.Error == nil && endpoint.CreateEvent {
+			endpoints[e].Error = endpoint.generateEvent()
+		} else {
+			if overallStatus < endpoint.Status {
+				overallStatus = endpoint.Status
+			}
+		}
+	}
+	var overallError error
+	for _, endpoint := range endpoints {
+		if endpoint.Error != nil {
+			overallError = multierror.Append(overallError, endpoint.Error)
+		}
+		if (!plugin.SuppressOKOutput && endpoint.Status == 0) || endpoint.Status > 0 {
+			fmt.Printf("Entity: %s URL: %s Status: %v Msg: %v Err: %v\n",
+				endpoint.EntityName, endpoint.URL, endpoint.Status, endpoint.StatusMsg, endpoint.Error)
+		}
+	}
+	return overallStatus, overallError
+}
+
+func parseEndpoints(endpointJSON string) ([]Endpoint, error) {
+	endpoints := []Endpoint{}
+	err := json.Unmarshal([]byte(endpointJSON), &endpoints)
+	if err != nil {
+		return []Endpoint{}, err
+	}
+
+	return endpoints, nil
+}
+
+// Set the defaults for endpoints
+func (e *Endpoint) UnmarshalJSON(data []byte) error {
+	type endpointAlias Endpoint
+	endpoint := &endpointAlias{
+		URL:                plugin.URL,
+		SearchString:       plugin.SearchString,
+		Headers:            plugin.Headers,
+		RedirectOK:         plugin.RedirectOK,
+		Timeout:            plugin.Timeout,
+		MTLSKeyFile:        plugin.MTLSKeyFile,
+		MTLSCertFile:       plugin.MTLSCertFile,
+		TrustedCAFile:      plugin.TrustedCAFile,
+		InsecureSkipVerify: plugin.InsecureSkipVerify,
+		CreateEvent:        plugin.CreateEvent,
+		EntityName:         plugin.EntityName,
+		CheckName:          plugin.CheckName,
+		EventsAPI:          plugin.EventsAPI,
+		Handlers:           plugin.Handlers,
+	}
+
+	_ = json.Unmarshal(data, endpoint)
+
+	*e = Endpoint(*endpoint)
+	return nil
+}
+
+func (e *Endpoint) generateEvent() error {
+	event := types.Event{}
+	check := types.Check{}
+	entity := types.Entity{}
+	event.Check = &check
+	event.Entity = &entity
+	event.Check.Name = e.CheckName
+	event.Check.Status = uint32(e.Status)
+	event.Check.Output = e.StatusMsg
+	event.Check.Handlers = e.Handlers
+	event.Entity.Name = e.EntityName
+	eventJSON, err := json.Marshal(event)
+	if err != nil {
+		fmt.Printf("Create event failed with error %s\n", err)
+		return err
+	}
+	fmt.Println(string(eventJSON))
+	_, err = http.Post(e.EventsAPI, "application/json", bytes.NewBuffer(eventJSON))
+	if err != nil {
+		fmt.Printf("The HTTP request to create event failed with error %s\n", err)
+		return err
+	}
+	return nil
+}

--- a/cmd/http-endpoints-check/main.go
+++ b/cmd/http-endpoints-check/main.go
@@ -536,11 +536,14 @@ func parseEndpoints(endpointJSON string) ([]Endpoint, error) {
 
 // Set the defaults for endpoints
 func (e *Endpoint) UnmarshalJSON(data []byte) error {
+	handlers := []string{}
+	headers := []string{}
 	type endpointAlias Endpoint
+
 	endpoint := &endpointAlias{
 		URL:                plugin.URL,
 		SearchString:       plugin.SearchString,
-		Headers:            plugin.Headers,
+		Headers:            append(headers, plugin.Headers...),
 		RedirectOK:         plugin.RedirectOK,
 		Timeout:            plugin.Timeout,
 		MTLSKeyFile:        plugin.MTLSKeyFile,
@@ -551,12 +554,12 @@ func (e *Endpoint) UnmarshalJSON(data []byte) error {
 		EntityName:         plugin.EntityName,
 		CheckName:          plugin.CheckName,
 		EventsAPI:          plugin.EventsAPI,
-		Handlers:           plugin.Handlers,
+		Handlers:           append(handlers, plugin.Handlers...),
 	}
-
 	_ = json.Unmarshal(data, endpoint)
 
 	*e = Endpoint(*endpoint)
+
 	return nil
 }
 
@@ -583,6 +586,7 @@ func (e *Endpoint) generateEvent() error {
 		fmt.Printf("  Check Name: %s\n", event.Check.Name)
 		fmt.Printf("  Check Status: %v\n", event.Check.Status)
 		fmt.Printf("  Check Output: %s\n", event.Check.Output)
+		fmt.Printf("  Check Handlers: %s\n", event.Check.Handlers)
 		fmt.Printf("  Event API: %s\n  Event Data: %s\n", e.EventsAPI, string(eventJSON))
 	} else {
 		_, err = http.Post(e.EventsAPI, "application/json", bytes.NewBuffer(eventJSON))

--- a/cmd/http-endpoints-check/main_test.go
+++ b/cmd/http-endpoints-check/main_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/sensu-community/sensu-plugin-sdk/sensu"
+	corev2 "github.com/sensu/sensu-go/api/core/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(t *testing.T) {
+}
+
+func TestExecuteCheck(t *testing.T) {
+
+	testCasesStringSearch := []struct {
+		status int
+		search string
+	}{
+		{sensu.CheckStateOK, "SUCCESS"},
+		{sensu.CheckStateCritical, "FAILURE"},
+	}
+
+	for _, tc := range testCasesStringSearch {
+		event := corev2.FixtureEvent("entity1", "check")
+		assert := assert.New(t)
+
+		var test = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			expectedMethod := "GET"
+			expectedURI := "/"
+			assert.Equal(expectedMethod, r.Method)
+			assert.Equal(expectedURI, r.RequestURI)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("SUCCESS"))
+		}))
+		_, err := url.ParseRequestURI(test.URL)
+		require.NoError(t, err)
+		plugin.URL = test.URL
+		plugin.SearchString = tc.search
+		status, err := checkArgs(event)
+		assert.NoError(err)
+		assert.Equal(0, status)
+		status, err = executeCheck(event)
+		assert.NoError(err)
+		assert.Equal(tc.status, status)
+	}
+
+	testCasesStatus := []struct {
+		returnStatus  int
+		httpStatus    int
+		allowRedirect bool
+	}{
+		{sensu.CheckStateOK, http.StatusOK, false},
+		{sensu.CheckStateOK, http.StatusOK, true},
+		{sensu.CheckStateWarning, http.StatusMovedPermanently, false},
+		{sensu.CheckStateCritical, http.StatusBadRequest, false},
+		{sensu.CheckStateCritical, http.StatusInternalServerError, false},
+	}
+
+	for _, tc := range testCasesStatus {
+		event := corev2.FixtureEvent("entity1", "check")
+		assert := assert.New(t)
+
+		var test = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			expectedMethod := "GET"
+			expectedURI := "/"
+			assert.Equal(expectedMethod, r.Method)
+			assert.Equal(expectedURI, r.RequestURI)
+			if tc.httpStatus >= http.StatusMultipleChoices && tc.httpStatus < http.StatusBadRequest {
+				w.Header().Add("Location", "https://google.com")
+			}
+			w.WriteHeader(tc.httpStatus)
+		}))
+		_, err := url.ParseRequestURI(test.URL)
+		require.NoError(t, err)
+		plugin.URL = test.URL
+		plugin.SearchString = ""
+		plugin.RedirectOK = tc.allowRedirect
+		status, err := checkArgs(event)
+		assert.NoError(err)
+		assert.Equal(0, status)
+		status, err = executeCheck(event)
+		assert.NoError(err)
+		assert.Equal(tc.returnStatus, status)
+	}
+
+	event := corev2.FixtureEvent("entity1", "check")
+	assert := assert.New(t)
+
+	var test = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal("Test Header 1 Value", r.Header.Get("Test-Header-1"))
+		assert.Equal("Test Header 2 Value", r.Header.Get("Test-Header-2"))
+	}))
+	_, err := url.ParseRequestURI(test.URL)
+	require.NoError(t, err)
+	plugin.URL = test.URL
+	plugin.SearchString = ""
+	plugin.Headers = []string{"Test-Header-1: Test Header 1 Value", "Test-Header-2: Test Header 2 Value"}
+	status, err := checkArgs(event)
+	assert.NoError(err)
+	assert.Equal(0, status)
+	status, err = executeCheck(event)
+	assert.NoError(err)
+	assert.Equal(sensu.CheckStateOK, status)
+}

--- a/cmd/http-endpoints-check/main_test.go
+++ b/cmd/http-endpoints-check/main_test.go
@@ -15,6 +15,40 @@ import (
 func TestMain(t *testing.T) {
 }
 
+/*
+func TestWorkingDirectory(t *testing.T) {
+	wd, _ := os.Getwd()
+	t.Log(wd)
+}
+*/
+
+func TestReadEndpointsFile(t *testing.T) {
+	testCases := []struct {
+		filename        string
+		expected_status int
+		expect_error    bool
+	}{
+		{"testdata/endpoints.json", sensu.CheckStateOK, false},
+		{"testdata/missing_endpoints.json", sensu.CheckStateCritical, true},
+	}
+	for _, tc := range testCases {
+		event := corev2.FixtureEvent("entity1", "check")
+		assert := assert.New(t)
+		plugin.Endpoints = ""
+		plugin.EndpointsFile = tc.filename
+		status, err := checkArgs(event)
+		assert.Equal(tc.expected_status, status)
+		if tc.expect_error {
+			assert.Error(err)
+		} else {
+			assert.NoError(err)
+		}
+	}
+	plugin.EndpointsFile = ""
+	plugin.Endpoints = ""
+
+}
+
 func TestExecuteCheck(t *testing.T) {
 
 	testCasesStringSearch := []struct {

--- a/cmd/http-endpoints-check/testdata/endpoints.json
+++ b/cmd/http-endpoints-check/testdata/endpoints.json
@@ -1,1 +1,15 @@
-[{"url":"https://sensu.io/"},{"url":"https://docs.sensu.io/"}]
+[
+	{
+		"event-check-name": "root_path",
+		"event-handlers": [
+			"handler1",
+			"handler2"
+		],
+		"url":"https://sensu.io/"
+	},
+	{
+		"create-event": true,
+		"event-check-name": "root_path",
+		"url":"https://docs.sensu.io/"
+	}
+]

--- a/cmd/http-endpoints-check/testdata/endpoints.json
+++ b/cmd/http-endpoints-check/testdata/endpoints.json
@@ -1,0 +1,1 @@
+[{"url":"https://sensu.io/"},{"url":"https://docs.sensu.io/"}]

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nixwiz/http-checks
+module github.com/sensu/http-checks
 
 go 1.13
 
@@ -9,6 +9,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/google/uuid v1.1.5 // indirect
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/itchyny/gojq v0.12.1
 	github.com/json-iterator/go v1.1.10 // indirect
 	github.com/magiconair/properties v1.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,10 +126,12 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=


### PR DESCRIPTION
Closes #11 
Add new http-endpoints-check command

This command can generate a seperate event for each url you want to check using the agent events api.
The command can take a json array representing multiple http-check calls.