### PR TITLE
return nil error and print error instead, to prevent usage msg

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,4 +13,4 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Run golangci-lint
-      uses: actions-contrib/golangci-lint@v1
+      uses: golangci/golangci-lint-action@v2

--- a/cmd/http-check/main.go
+++ b/cmd/http-check/main.go
@@ -181,7 +181,8 @@ func executeCheck(event *types.Event) (int, error) {
 
 	checkURL, err := url.Parse(plugin.URL)
 	if err != nil {
-		return sensu.CheckStateCritical, err
+		fmt.Printf("url parse error: %s\n", err)
+		return sensu.CheckStateCritical, nil
 	}
 	if checkURL.Scheme == "https" {
 		client.Transport.(*http.Transport).TLSClientConfig = &tlsConfig
@@ -189,7 +190,8 @@ func executeCheck(event *types.Event) (int, error) {
 
 	req, err := http.NewRequest("GET", plugin.URL, nil)
 	if err != nil {
-		return sensu.CheckStateCritical, err
+		fmt.Printf("request creation error: %s\n", err)
+		return sensu.CheckStateCritical, nil
 	}
 
 	if len(plugin.Headers) > 0 {
@@ -201,18 +203,16 @@ func executeCheck(event *types.Event) (int, error) {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return sensu.CheckStateCritical, err
+		fmt.Printf("request error: %s\n", err)
+		return sensu.CheckStateCritical, nil
 	}
 
 	defer resp.Body.Close()
 
-	if err != nil {
-		return sensu.CheckStateCritical, err
-	}
-
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return sensu.CheckStateCritical, err
+		fmt.Printf("response body read error: %s\n", err)
+		return sensu.CheckStateCritical, nil
 	}
 
 	if len(plugin.SearchString) > 0 {

--- a/cmd/http-perf/main.go
+++ b/cmd/http-perf/main.go
@@ -195,7 +195,8 @@ func executeCheck(event *types.Event) (int, error) {
 
 	checkURL, err := url.Parse(plugin.URL)
 	if err != nil {
-		return sensu.CheckStateCritical, err
+		fmt.Printf("url parse error: %s\n", err)
+		return sensu.CheckStateCritical, nil
 	}
 	if checkURL.Scheme == "https" {
 		client.Transport.(*http.Transport).TLSClientConfig = &tlsConfig
@@ -203,7 +204,8 @@ func executeCheck(event *types.Event) (int, error) {
 
 	req, err := http.NewRequest("GET", plugin.URL, nil)
 	if err != nil {
-		return sensu.CheckStateCritical, err
+		fmt.Printf("request creation error: %s\n", err)
+		return sensu.CheckStateCritical, nil
 	}
 	if len(plugin.Headers) > 0 {
 		for _, header := range plugin.Headers {
@@ -251,7 +253,8 @@ func executeCheck(event *types.Event) (int, error) {
 	start = time.Now()
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	if err != nil {
-		return sensu.CheckStateCritical, err
+		fmt.Printf("request error: %s\n", err)
+		return sensu.CheckStateCritical, nil
 	}
 	totalRequestDuration = time.Since(start)
 


### PR DESCRIPTION
Currently sdk logic causes the check output to be polluted with the plugin usage message  when there is a non-zero return status in some operational situations.

This PR changes the plugin executeCheck return logic such that usage message should only appear for  checkArgs argument validation failures.
