### PR TITLE
Add response code flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,17 @@ Available Commands:
   version     Print the version number of this plugin
 
 Flags:
-  -u, --url string               URL to test (default "http://localhost:80/")
-  -s, --search-string string     String to search for, if not provided do status check only
-  -r, --redirect-ok              Allow redirects
-  -T, --timeout int              Request timeout in seconds (default 15)
   -H, --header strings           Additional header(s) to send in check request
+  -h, --help                     help for http-check
+  -i, --insecure-skip-verify     Skip TLS certificate verification (not recommended!)
   -C, --mtls-cert-file string    Certificate file for mutual TLS auth in PEM format
   -K, --mtls-key-file string     Key file for mutual TLS auth in PEM format
+  -r, --redirect-ok              Allow redirects
+  -R, --response-code int        Resposne Status Code to expect
+  -s, --search-string string     String to search for, if not provided do status check only
+  -T, --timeout int              Request timeout in seconds (default 15)
   -t, --trusted-ca-file string   TLS CA certificate bundle in PEM format
-  -i, --insecure-skip-verify     Skip TLS certificate verification (not recommended!)
-  -h, --help                     help for http-check
+  -u, --url string               URL to test (default "http://localhost:80/")
 
 Use "http-check [command] --help" for more information about a command.
 ```
@@ -98,9 +99,11 @@ http-check OK: HTTP Status 200 for http://localhost:8000/health
 
 #### Note(s)
 
-* When using `--redirect-ok` it affects both the string search and status checkfunctionality.
+* When using `--redirect-ok` it affects both the string search and status check functionality.
   - For a string search, if true, it searches for the string in the eventual destination. 
-  - For a status check, if false, receiving a redirect will return a `warning` status.  If true, it will return an `ok` status.
+  - When the `--response-code` option is used in conjunction with `--redirect-ok`, `--response-code` will be evaluated off
+  of the status of the eventual destination.
+  - For an unspecified status check, if `--redirect-ok` is false, receiving a redirect will return a `warning` status.  If true, it will return an `ok` status.
 * Headers should be in the form of "Header-Name: Header value".
 
 ### http-perf

--- a/cmd/http-check/main_test.go
+++ b/cmd/http-check/main_test.go
@@ -15,6 +15,7 @@ import (
 func TestMain(t *testing.T) {
 }
 
+// TestExecuteCheck mega test as each case mutates global state
 func TestExecuteCheck(t *testing.T) {
 
 	testCasesStringSearch := []struct {
@@ -26,24 +27,27 @@ func TestExecuteCheck(t *testing.T) {
 	}
 
 	for _, tc := range testCasesStringSearch {
-		event := corev2.FixtureEvent("entity1", "check")
-		assert := assert.New(t)
+		t.Run("StringSerach: "+tc.search, func(t *testing.T) {
+			event := corev2.FixtureEvent("entity1", "check")
+			assert := assert.New(t)
 
-		var test = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			expectedMethod := "GET"
-			expectedURI := "/"
-			assert.Equal(expectedMethod, r.Method)
-			assert.Equal(expectedURI, r.RequestURI)
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("SUCCESS"))
-		}))
-		_, err := url.ParseRequestURI(test.URL)
-		require.NoError(t, err)
-		plugin.URL = test.URL
-		plugin.SearchString = tc.search
-		status, err := executeCheck(event)
-		assert.NoError(err)
-		assert.Equal(tc.status, status)
+			var test = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "GET"
+				expectedURI := "/"
+				assert.Equal(expectedMethod, r.Method)
+				assert.Equal(expectedURI, r.RequestURI)
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("SUCCESS"))
+			}))
+			defer test.Close()
+			_, err := url.ParseRequestURI(test.URL)
+			require.NoError(t, err)
+			plugin.URL = test.URL
+			plugin.SearchString = tc.search
+			status, err := executeCheck(event)
+			assert.NoError(err)
+			assert.Equal(tc.status, status)
+		})
 	}
 
 	testCasesStatus := []struct {
@@ -59,42 +63,144 @@ func TestExecuteCheck(t *testing.T) {
 	}
 
 	for _, tc := range testCasesStatus {
+		t.Run("StatusCodes", func(t *testing.T) {
+			event := corev2.FixtureEvent("entity1", "check")
+			assert := assert.New(t)
+
+			var test = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				expectedMethod := "GET"
+				expectedURI := "/"
+				assert.Equal(expectedMethod, r.Method)
+				assert.Equal(expectedURI, r.RequestURI)
+				if tc.httpStatus >= http.StatusMultipleChoices && tc.httpStatus < http.StatusBadRequest {
+					w.Header().Add("Location", "https://google.com")
+				}
+				w.WriteHeader(tc.httpStatus)
+			}))
+			defer test.Close()
+			_, err := url.ParseRequestURI(test.URL)
+			require.NoError(t, err)
+			plugin.URL = test.URL
+			plugin.SearchString = ""
+			plugin.RedirectOK = tc.allowRedirect
+			status, err := executeCheck(event)
+			assert.NoError(err)
+			assert.Equal(tc.returnStatus, status)
+		})
+	}
+
+	t.Run("HeaderValue", func(t *testing.T) {
 		event := corev2.FixtureEvent("entity1", "check")
 		assert := assert.New(t)
 
 		var test = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			expectedMethod := "GET"
-			expectedURI := "/"
-			assert.Equal(expectedMethod, r.Method)
-			assert.Equal(expectedURI, r.RequestURI)
-			if tc.httpStatus >= http.StatusMultipleChoices && tc.httpStatus < http.StatusBadRequest {
-				w.Header().Add("Location", "https://google.com")
-			}
-			w.WriteHeader(tc.httpStatus)
+			assert.Equal("Test Header 1 Value", r.Header.Get("Test-Header-1"))
+			assert.Equal("Test Header 2 Value", r.Header.Get("Test-Header-2"))
 		}))
+		defer test.Close()
 		_, err := url.ParseRequestURI(test.URL)
 		require.NoError(t, err)
 		plugin.URL = test.URL
 		plugin.SearchString = ""
-		plugin.RedirectOK = tc.allowRedirect
+		plugin.Headers = []string{"Test-Header-1: Test Header 1 Value", "Test-Header-2: Test Header 2 Value"}
 		status, err := executeCheck(event)
 		assert.NoError(err)
-		assert.Equal(tc.returnStatus, status)
-	}
+		assert.Equal(sensu.CheckStateOK, status)
+	})
 
-	event := corev2.FixtureEvent("entity1", "check")
-	assert := assert.New(t)
+	t.Run("Check Response Code", func(t *testing.T) {
+		testSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/redirect/":
+				http.Redirect(w, r, "/", http.StatusMovedPermanently)
+			case "/forbidden/":
+				w.WriteHeader(http.StatusForbidden)
+			case "/error/":
+				w.WriteHeader(http.StatusInternalServerError)
+			default:
+				w.WriteHeader(http.StatusOK)
+				w.Write([]byte("<h1>Success</h1>"))
+			}
+		}))
+		defer testSrv.Close()
 
-	var test = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal("Test Header 1 Value", r.Header.Get("Test-Header-1"))
-		assert.Equal("Test Header 2 Value", r.Header.Get("Test-Header-2"))
-	}))
-	_, err := url.ParseRequestURI(test.URL)
-	require.NoError(t, err)
-	plugin.URL = test.URL
-	plugin.SearchString = ""
-	plugin.Headers = []string{"Test-Header-1: Test Header 1 Value", "Test-Header-2: Test Header 2 Value"}
-	status, err := executeCheck(event)
-	assert.NoError(err)
-	assert.Equal(sensu.CheckStateOK, status)
+		type Options struct {
+			FollowRedirects bool
+			SearchString    string
+		}
+
+		testCases := []struct {
+			Name             string
+			URL              string
+			Options          Options
+			ResponseCode     int
+			ExpectedExitCode int
+		}{
+			{
+				Name:             "Expect OK",
+				URL:              "/",
+				ResponseCode:     200,
+				ExpectedExitCode: sensu.CheckStateOK,
+			}, {
+				Name:             "Expect OK, got forbidden",
+				URL:              "/forbidden/",
+				ResponseCode:     200,
+				ExpectedExitCode: sensu.CheckStateCritical,
+			}, {
+				Name:             "Expect 301",
+				URL:              "/redirect/",
+				ResponseCode:     301,
+				ExpectedExitCode: sensu.CheckStateOK,
+			}, {
+				Name:             "Expect 301 With Follow Redirect, got OK",
+				URL:              "/redirect/",
+				ResponseCode:     301,
+				Options:          Options{FollowRedirects: true},
+				ExpectedExitCode: sensu.CheckStateCritical,
+			}, {
+				Name:             "Expect OK, got forbidden",
+				URL:              "/forbidden/",
+				ResponseCode:     200,
+				ExpectedExitCode: sensu.CheckStateCritical,
+			}, {
+				Name:             "Expect Accepted, got OK",
+				URL:              "/",
+				ResponseCode:     201,
+				ExpectedExitCode: sensu.CheckStateCritical,
+			}, {
+				Name:             "Expect OK with Search String",
+				URL:              "/",
+				ResponseCode:     200,
+				Options:          Options{SearchString: "Success"},
+				ExpectedExitCode: sensu.CheckStateOK,
+			}, {
+				Name:             "Expect 500 with Search String, got OK",
+				URL:              "/",
+				ResponseCode:     500,
+				Options:          Options{SearchString: "Success"},
+				ExpectedExitCode: sensu.CheckStateCritical,
+			}, {
+				Name:             "Expect OK with Missing Search String, get OK",
+				URL:              "/",
+				ResponseCode:     200,
+				Options:          Options{SearchString: "Fizz"},
+				ExpectedExitCode: sensu.CheckStateCritical,
+			},
+		}
+		event := corev2.FixtureEvent("entity1", "check")
+
+		for _, tc := range testCases {
+			t.Run(tc.Name, func(t *testing.T) {
+				plugin.Headers = []string{}
+				plugin.InsecureSkipVerify = true
+				plugin.RedirectOK = tc.Options.FollowRedirects
+				plugin.ResponseCode = tc.ResponseCode
+				plugin.SearchString = tc.Options.SearchString
+				plugin.URL = testSrv.URL + tc.URL
+				actualExitCode, _ := executeCheck(event)
+				assert.Equal(t, tc.ExpectedExitCode, actualExitCode)
+			})
+		}
+
+	})
 }

--- a/cmd/http-check/main_test.go
+++ b/cmd/http-check/main_test.go
@@ -119,7 +119,7 @@ func TestExecuteCheck(t *testing.T) {
 				w.WriteHeader(http.StatusInternalServerError)
 			default:
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("<h1>Success</h1>"))
+				_, _ = w.Write([]byte("<h1>Success</h1>"))
 			}
 		}))
 		defer testSrv.Close()


### PR DESCRIPTION
Closes https://github.com/sensu/http-checks/issues/16

## What
* Added a response code flag to http-check in the styling of the ruby check: https://github.com/sensu-plugins/sensu-plugins-http/blob/master/bin/check-http.rb
* Updated unit tests to keep the sequential test execution but add names to test cases (and also close test http servers)
* Add warnings about --redirect-ok and --response-code

## Qs

Do y'all prefer to just warn and exit when using --redirect-ok and --response-code in conjunction? It doesn't _need_ to work that way, but it feels kinda silly to specify both.