### PR TITLE
Handle Host header

### DIFF
--- a/cmd/http-check/main.go
+++ b/cmd/http-check/main.go
@@ -197,7 +197,13 @@ func executeCheck(event *types.Event) (int, error) {
 	if len(plugin.Headers) > 0 {
 		for _, header := range plugin.Headers {
 			headerSplit := strings.SplitN(header, ":", 2)
-			req.Header.Set(strings.TrimSpace(headerSplit[0]), strings.TrimSpace(headerSplit[1]))
+			headerKey := strings.TrimSpace(headerSplit[0])
+			headerValue := strings.TrimSpace(headerSplit[1])
+			if strings.EqualFold(headerKey, "host") {
+				req.Host = headerValue
+				continue
+			}
+			req.Header.Set(headerKey, headerValue)
 		}
 	}
 

--- a/cmd/http-check/main_test.go
+++ b/cmd/http-check/main_test.go
@@ -88,12 +88,13 @@ func TestExecuteCheck(t *testing.T) {
 	var test = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal("Test Header 1 Value", r.Header.Get("Test-Header-1"))
 		assert.Equal("Test Header 2 Value", r.Header.Get("Test-Header-2"))
+		assert.Equal("foo.bar.tld", r.Host)
 	}))
 	_, err := url.ParseRequestURI(test.URL)
 	require.NoError(t, err)
 	plugin.URL = test.URL
 	plugin.SearchString = ""
-	plugin.Headers = []string{"Test-Header-1: Test Header 1 Value", "Test-Header-2: Test Header 2 Value"}
+	plugin.Headers = []string{"Test-Header-1: Test Header 1 Value", "Test-Header-2: Test Header 2 Value", "Host: foo.bar.tld"}
 	status, err := executeCheck(event)
 	assert.NoError(err)
 	assert.Equal(sensu.CheckStateOK, status)

--- a/cmd/http-get/main.go
+++ b/cmd/http-get/main.go
@@ -173,7 +173,13 @@ func executeCheck(event *corev2.Event) (int, error) {
 	if len(plugin.Headers) > 0 {
 		for _, header := range plugin.Headers {
 			headerSplit := strings.SplitN(header, ":", 2)
-			req.Header.Set(strings.TrimSpace(headerSplit[0]), strings.TrimSpace(headerSplit[1]))
+			headerKey := strings.TrimSpace(headerSplit[0])
+			headerValue := strings.TrimSpace(headerSplit[1])
+			if strings.EqualFold(headerKey, "host") {
+				req.Host = headerValue
+				continue
+			}
+			req.Header.Set(headerKey, headerValue)
 		}
 	}
 

--- a/cmd/http-json/main.go
+++ b/cmd/http-json/main.go
@@ -203,7 +203,13 @@ func executeCheck(event *corev2.Event) (int, error) {
 	if len(plugin.Headers) > 0 {
 		for _, header := range plugin.Headers {
 			headerSplit := strings.SplitN(header, ":", 2)
-			req.Header.Set(strings.TrimSpace(headerSplit[0]), strings.TrimSpace(headerSplit[1]))
+			headerKey := strings.TrimSpace(headerSplit[0])
+			headerValue := strings.TrimSpace(headerSplit[1])
+			if strings.EqualFold(headerKey, "host") {
+				req.Host = headerValue
+				continue
+			}
+			req.Header.Set(headerKey, headerValue)
 		}
 	}
 

--- a/cmd/http-json/main_test.go
+++ b/cmd/http-json/main_test.go
@@ -76,6 +76,7 @@ func TestExecuteCheck(t *testing.T) {
 	var test = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal("Test Header 1 Value", r.Header.Get("Test-Header-1"))
 		assert.Equal("Test Header 2 Value", r.Header.Get("Test-Header-2"))
+		assert.Equal("foo.bar.tld", r.Host)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(testJSON)
 	}))
@@ -84,7 +85,7 @@ func TestExecuteCheck(t *testing.T) {
 	plugin.URL = test.URL
 	plugin.Query = ".number"
 	plugin.Expression = "== 10"
-	plugin.Headers = []string{"Test-Header-1: Test Header 1 Value", "Test-Header-2: Test Header 2 Value"}
+	plugin.Headers = []string{"Test-Header-1: Test Header 1 Value", "Test-Header-2: Test Header 2 Value", "Host: foo.bar.tld"}
 	status, err := executeCheck(event)
 	assert.NoError(err)
 	assert.Equal(sensu.CheckStateOK, status)

--- a/cmd/http-perf/main.go
+++ b/cmd/http-perf/main.go
@@ -210,7 +210,13 @@ func executeCheck(event *types.Event) (int, error) {
 	if len(plugin.Headers) > 0 {
 		for _, header := range plugin.Headers {
 			headerSplit := strings.SplitN(header, ":", 2)
-			req.Header.Set(strings.TrimSpace(headerSplit[0]), strings.TrimSpace(headerSplit[1]))
+			headerKey := strings.TrimSpace(headerSplit[0])
+			headerValue := strings.TrimSpace(headerSplit[1])
+			if strings.EqualFold(headerKey, "host") {
+				req.Host = headerValue
+				continue
+			}
+			req.Header.Set(headerKey, headerValue)
 		}
 	}
 

--- a/cmd/http-perf/main_test.go
+++ b/cmd/http-perf/main_test.go
@@ -28,13 +28,14 @@ func TestExecuteCheck(t *testing.T) {
 		assert.Equal(expectedURI, r.RequestURI)
 		assert.Equal("Test Header 1 Value", r.Header.Get("Test-Header-1"))
 		assert.Equal("Test Header 2 Value", r.Header.Get("Test-Header-2"))
+		assert.Equal("foo.bar.tld", r.Host)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("SUCCESS"))
 	}))
 	_, err := url.ParseRequestURI(test.URL)
 	require.NoError(t, err)
 	plugin.URL = test.URL
-	plugin.Headers = []string{"Test-Header-1: Test Header 1 Value", "Test-Header-2: Test Header 2 Value"}
+	plugin.Headers = []string{"Test-Header-1: Test Header 1 Value", "Test-Header-2: Test Header 2 Value", "Host: foo.bar.tld"}
 	warning, _ = time.ParseDuration("2s")
 	critical, _ = time.ParseDuration("5s")
 	status, err := executeCheck(event)


### PR DESCRIPTION
The `Host` header is a special case of client requests.

From https://pkg.go.dev/net/http#Request:
> For client requests, Host optionally overrides the Host
header to send. If empty, the Request.Write method uses
the value of URL.Host. Host may contain an international
domain name.